### PR TITLE
Update cmsvirt.c

### DIFF
--- a/src/cmsvirt.c
+++ b/src/cmsvirt.c
@@ -1096,9 +1096,10 @@ cmsHPROFILE CMSEXPORT cmsTransform2DeviceLink(cmsHTRANSFORM hTransform, cmsFloat
             goto Error;
     }
 
-    // On the output side too
+    // On the output side too. Note that due to V2/V4 PCS encoding on lab we cannot fix white misalignments
     if ((xform ->ExitColorSpace) == cmsSigLabData && (Version < 4.0)) {
 
+        dwFlags |= cmsFLAGS_NOWHITEONWHITEFIXUP;
         if (!cmsPipelineInsertStage(LUT, cmsAT_END, _cmsStageAllocLabV4ToV2(ContextID)))
             goto Error;
     }


### PR DESCRIPTION
Fix wrong white fixup on V2 PCS when building input profiles. Thanks to Maurice Luttmer for finding the bug.